### PR TITLE
Fix version check

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -34,7 +34,7 @@ main() {
 
   version='2.8'
   gimp_path_version_string=$($gimp_path --version)
-  if echo "$gimp_path_version_string" | grep -qv "version $version"; then
+  if echo "$gimp_path_version_string" | grep -qvF "$version"; then
     printf "${YELLOW}Gimp version is not installed!${NORMAL} Please install Gimp $version first!\n"
     exit 1
   fi


### PR DESCRIPTION
If the user OS language isn't english the version checking could fail no matter the GIMP version installed.

Added the -F option to treat the pattern as a string and not a RegEx (because of the dot).