### PR TITLE
Update install script to Gimp 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-To help a fellow deviant, I've put together a download that anyone with Gimp 2.8 on Linux can use to make their copy of Gimp look more like Adobe Photoshop and make people more comfortable.
+To help a fellow deviant, I've put together a download that anyone with Gimp 2.10 on Linux can use to make their copy of Gimp look more like Adobe Photoshop and make people more comfortable.
 
 I've taken various bits of guides online and various tweaks.
 All you have to do is download the file, unzip it.
-Then in the file manager go to your home folder, show hidden files, delete or move your old .gimp-2.8 configuration folder out of the way, and replace with the new one.
+Then in the file manager go to your home folder, show hidden files, delete or move your old .gimp-2.10 configuration folder out of the way, and replace with the new one.
 Then load Gimp.
 
 Please let me know if it works for you or if it fails.
@@ -13,7 +13,7 @@ Please let me know if it works for you or if it fails.
 
 __Disclaimer:__ _GimpPs supports Windows, but works best on OS X and Linux._
 
-* Gimp `2.8`
+* Gimp `2.10`
 * `git` should be installed
 
 ### Basic Installation
@@ -36,8 +36,8 @@ sh -c "$(wget https://raw.githubusercontent.com/doctormo/GimpPs/master/tools/ins
 
 	# exit gimp first
 	cd $HOME/Library/Application\ Support/GIMP
-	mv 2.8 2.8.backup
-	git clone --depth=1 https://github.com/doctormo/GimpPs.git 2.8
+	mv 2.10 2.10.backup
+	git clone --depth=1 https://github.com/doctormo/GimpPs.git 2.10
 
 ### Windows installation
 
@@ -45,13 +45,13 @@ sh -c "$(wget https://raw.githubusercontent.com/doctormo/GimpPs/master/tools/ins
 
 	# exit gimp first
 	cd $Env:UserProfile
-	mv .gimp-2.8 .gimp-2.8.backup
-	git clone --depth=1 https://github.com/doctormo/GimpPs.git .gimp-2.8
+	mv .gimp-2.10 .gimp-2.10.backup
+	git clone --depth=1 https://github.com/doctormo/GimpPs.git .gimp-2.10
 
 #### via cmd:
 
 	# exit gimp first
 	cd %USERPROFILE%
-	ren .gimp-2.8 .gimp-2.8.backup
-	git clone --depth=1 https://github.com/doctormo/GimpPs.git .gimp-2.8
+	ren .gimp-2.10 .gimp-2.10.backup
+	git clone --depth=1 https://github.com/doctormo/GimpPs.git .gimp-2.10
 People generally get biased in the discussion of GIMP Vs Photoshop but they don't know how powerful GIMP really is. You can do all the effects of you use GIMP Wisely.

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ sh -c "$(wget https://raw.githubusercontent.com/doctormo/GimpPs/master/tools/ins
 	cd %USERPROFILE%
 	ren .gimp-2.8 .gimp-2.8.backup
 	git clone --depth=1 https://github.com/doctormo/GimpPs.git .gimp-2.8
-People generally get biased in the discussion of GIMP Vs Photoshop but they don't know how powerful GIMP really is.You can do all the effects of you use GIMP Wisely.
+People generally get biased in the discussion of GIMP Vs Photoshop but they don't know how powerful GIMP really is. You can do all the effects of you use GIMP Wisely.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -31,7 +31,7 @@ main() {
     exit 1
   fi
 
-  version='2.8'
+  version='2.10'
   gimp_path_version_string=$($gimp_path --version)
   if echo "$gimp_path_version_string" | grep -qvF "$version"; then
     printf "${YELLOW}Gimp version is not installed!${NORMAL} Please install Gimp $version first!\n"
@@ -44,7 +44,7 @@ main() {
     exit 1
   }
 
-  gimp_ps_directory="$HOME/.gimp-$version"
+  gimp_ps_directory="$HOME/.config/GIMP/$version"
 
   # Backup previous directory, if any
   if [ -e "$gimp_ps_directory" ]; then


### PR DESCRIPTION
I updated the install script to install for Gimp 2.10, fixing #19 - the actual configs remained the same. Updated Readme to reflect the changes (now says 2.10 not 2.8).
It seems as if the config needs some updating for the new version as on first startup after installing GimpPs, the toolbox sidebar on the right filled half my screen - it can easily be moved to the side though and apart from that it seems to work flawlessly (on a cursory inspection).

_Also added a missing whitespace in the last line of the Readme because it bothered me_ :eyes: